### PR TITLE
Initialize React + Vite with Tailwind landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Nabazza
-For engineering purposes and coding
+
+This project uses [Vite](https://vitejs.dev/) with React and Tailwind CSS.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nabazza</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nabazza",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,13 @@
+import Navbar from './components/Navbar.jsx'
+import Hero from './components/Hero.jsx'
+
+function App() {
+  return (
+    <>
+      <Navbar />
+      <Hero />
+    </>
+  )
+}
+
+export default App

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,11 @@
+export default function Hero() {
+  return (
+    <section className="bg-gray-100">
+      <div className="container mx-auto px-4 py-20 text-center">
+        <h1 className="text-4xl font-bold mb-4">Welcome to Nabazza</h1>
+        <p className="text-gray-700 mb-6">Build your web presence with ease.</p>
+        <a href="#" className="bg-blue-600 text-white px-6 py-2 rounded-md">Get Started</a>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,14 @@
+export default function Navbar() {
+  return (
+    <nav className="bg-white shadow">
+      <div className="container mx-auto px-4 py-4 flex justify-between items-center">
+        <div className="text-2xl font-bold">Nabazza</div>
+        <ul className="flex space-x-4">
+          <li><a href="#" className="text-gray-700 hover:text-gray-900">Home</a></li>
+          <li><a href="#" className="text-gray-700 hover:text-gray-900">About</a></li>
+          <li><a href="#" className="text-gray-700 hover:text-gray-900">Contact</a></li>
+        </ul>
+      </div>
+    </nav>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,jsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold React app using Vite
- configure Tailwind CSS
- add Navbar and Hero components for landing page

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e2839b688320bb43683245bd9deb