### PR TITLE
Add Vite + React CPT Quest prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoquipMarine CPT Quest</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "nabazza",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,17 @@
+import SeaBackground from './components/SeaBackground'
+import VesselCanvas from './components/VesselCanvas'
+import CPTGraph from './components/CPTGraph'
+import ControlPanel from './components/ControlPanel'
+
+export default function App() {
+  return (
+    <div className="relative w-screen h-screen overflow-hidden">
+      <SeaBackground />
+      <VesselCanvas />
+      <div className="absolute top-0 right-0 p-4 space-y-4">
+        <CPTGraph />
+        <ControlPanel />
+      </div>
+    </div>
+  )
+}

--- a/src/components/CPTGraph.jsx
+++ b/src/components/CPTGraph.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  Chart,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Legend,
+} from 'chart.js'
+import { Line } from 'react-chartjs-2'
+
+Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Legend)
+
+export default function CPTGraph() {
+  const chartRef = useRef(null)
+  const [data, setData] = useState({
+    labels: [],
+    datasets: [
+      { label: 'qc', data: [], borderColor: 'red' },
+      { label: 'fs', data: [], borderColor: 'green' },
+      { label: 'u2', data: [], borderColor: 'blue' },
+    ],
+  })
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setData(prev => {
+        const nextLabel = prev.labels.length + 1
+        return {
+          labels: [...prev.labels, nextLabel],
+          datasets: prev.datasets.map(ds => ({
+            ...ds,
+            data: [...ds.data, Math.random() * 100],
+          })),
+        }
+      })
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const exportPNG = () => {
+    const url = chartRef.current.toBase64Image()
+    const link = document.createElement('a')
+    link.download = 'cpt-graph.png'
+    link.href = url
+    link.click()
+  }
+
+  return (
+    <div className="bg-white p-2">
+      <Line ref={chartRef} data={data} />
+      <button onClick={exportPNG} className="mt-2 px-2 py-1 bg-gray-200">Export PNG</button>
+    </div>
+  )
+}

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react'
+
+export default function ControlPanel() {
+  const [player, setPlayer] = useState(() => localStorage.getItem('player') || '')
+  const [score, setScore] = useState(0)
+  const [highScore, setHighScore] = useState(() => Number(localStorage.getItem('highScore') || 0))
+  const [running, setRunning] = useState(false)
+  const [muted, setMuted] = useState(false)
+
+  useEffect(() => {
+    localStorage.setItem('player', player)
+  }, [player])
+
+  useEffect(() => {
+    if (score > highScore) {
+      setHighScore(score)
+      localStorage.setItem('highScore', String(score))
+    }
+  }, [score, highScore])
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(() => setScore(s => s + 1), 1000)
+    return () => clearInterval(id)
+  }, [running])
+
+  return (
+    <div className="mt-4 p-2 bg-white">
+      <div className="mb-2">
+        <input
+          className="border p-1"
+          placeholder="Player name"
+          value={player}
+          onChange={e => setPlayer(e.target.value)}
+        />
+      </div>
+      <div className="mb-2">Score: {score} | High Score: {highScore}</div>
+      <div className="space-x-2">
+        <button onClick={() => setRunning(true)} className="px-2 py-1 bg-green-200">Start</button>
+        <button onClick={() => setRunning(false)} className="px-2 py-1 bg-red-200">Stop</button>
+        <button onClick={() => { setScore(0); setRunning(false); }} className="px-2 py-1 bg-gray-200">Reset</button>
+        <button onClick={() => setMuted(m => !m)} className="px-2 py-1 bg-yellow-200">
+          {muted ? 'Unmute' : 'Mute'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SeaBackground.jsx
+++ b/src/components/SeaBackground.jsx
@@ -1,0 +1,3 @@
+export default function SeaBackground() {
+  return <div className="absolute inset-0 bg-blue-200" />
+}

--- a/src/components/VesselCanvas.jsx
+++ b/src/components/VesselCanvas.jsx
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react'
+
+export default function VesselCanvas() {
+  const canvasRef = useRef(null)
+
+  useEffect(() => {
+    const ctx = canvasRef.current.getContext('2d')
+    ctx.fillStyle = '#555'
+    ctx.fillRect(50, 50, 100, 30)
+  }, [])
+
+  return <canvas ref={canvasRef} width={200} height={150} className="absolute inset-x-0 top-1/4 mx-auto" />
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body, #root {
+  @apply w-full h-full;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold Vite + React project with Tailwind and dev/build/preview scripts
- implement GeoquipMarine CPT Quest components: SeaBackground, VesselCanvas, CPTGraph with PNG export, ControlPanel storing player name and high score in localStorage

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e2b4e18c8320bbbd98c5fba8af97